### PR TITLE
Remove internal line breaks in picks.csv

### DIFF
--- a/run.py
+++ b/run.py
@@ -500,7 +500,9 @@ def pred_fn(args, data_reader, figure_dir=None, result_dir=None, log_dir=None):
                                         args=args),
                                 range(len(pred_batch)))
         for i in range(len(fname_batch)):
-          fclog.write("{},{},{},{},{}\n".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1], picks_batch[i][1][0], picks_batch[i][1][1]))
+          row = "{},{},{},{},{}".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1],
+                                        picks_batch[i][1][0], picks_batch[i][1][1]).replace("\n", "")
+          fclog.write(row+"\n")
 
         if last_batch:
           break
@@ -523,7 +525,9 @@ def pred_fn(args, data_reader, figure_dir=None, result_dir=None, log_dir=None):
                                         args=args),
                                 range(len(pred_batch)))
         for i in range(len(fname_batch)):
-          fclog.write("{},{},{},{},{}\n".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1], picks_batch[i][1][0], picks_batch[i][1][1]))
+          row = "{},{},{},{},{}".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1],
+                                        picks_batch[i][1][0], picks_batch[i][1][1]).replace("\n", "")
+          fclog.write(row+"\n")
         # fclog.flush()
 
     fclog.close()


### PR DESCRIPTION
I highlighted this issue on github and in a [stack exchange post](https://stackoverflow.com/questions/62413052/unwanted-newlines-for-a-file-write-csv-when-entries-are-overfull-too-long).

When the probability threshold was set low such that PhaseNet made many picks, some of the column entries would become overfull and it would automatically insert a line break and bump subsequent entries to a new row. This led to all sort of complications later, especially when reading the csv with pandas. The stack exchange post clarifies the problem and the solution which I have added in this pull request.