### PR TITLE
Cleaned picks.csv formatting with the csv library

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ import pandas as pd
 import threading
 import multiprocessing
 from functools import partial
+import csv
 
 def read_args():
 
@@ -461,8 +462,10 @@ def pred_fn(args, data_reader, figure_dir=None, result_dir=None, log_dir=None):
     else:
       num_pool = 2
     pool = multiprocessing.Pool(num_pool)
-    fclog = open(os.path.join(log_dir, args.fpred+'.csv'), 'w')
-    fclog.write("fname,itp,tp_prob,its,ts_prob\n") 
+    
+    with open(os.path.join(log_dir, args.fpred + '.csv'), 'w') as fclog:
+      writer = csv.writer(fclog)
+      writer.writerow(["fname", "itp", "tp_prob", "its", "ts_prob"])
     
     if args.input_mseed:
 
@@ -499,10 +502,13 @@ def pred_fn(args, data_reader, figure_dir=None, result_dir=None, log_dir=None):
                                         figure_dir = figure_dir,
                                         args=args),
                                 range(len(pred_batch)))
-        for i in range(len(fname_batch)):
-          row = "{},{},{},{},{}".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1],
-                                        picks_batch[i][1][0], picks_batch[i][1][1]).replace("\n", "")
-          fclog.write(row+"\n")
+        
+        with open(os.path.join(log_dir, args.fpred + '.csv'), 'a') as fclog:
+          writer = csv.writer(fclog)
+          for i in range(len(fname_batch)):
+            row = [fname_batch[i].decode(), picks_batch[i][0][0].tolist(), picks_batch[i][0][1].tolist(), 
+                   picks_batch[i][1][0].tolist(), picks_batch[i][1][1].tolist()]
+            writer.writerow(row)
 
         if last_batch:
           break
@@ -524,11 +530,13 @@ def pred_fn(args, data_reader, figure_dir=None, result_dir=None, log_dir=None):
                                         figure_dir = figure_dir,
                                         args=args),
                                 range(len(pred_batch)))
-        for i in range(len(fname_batch)):
-          row = "{},{},{},{},{}".format(fname_batch[i].decode(), picks_batch[i][0][0], picks_batch[i][0][1],
-                                        picks_batch[i][1][0], picks_batch[i][1][1]).replace("\n", "")
-          fclog.write(row+"\n")
-        # fclog.flush()
+        
+    with open(os.path.join(log_dir, args.fpred + '.csv'), 'a') as fclog:
+      writer = csv.writer(fclog)
+      for i in range(len(fname_batch)):
+        row = [fname_batch[i].decode(), picks_batch[i][0][0].tolist(), picks_batch[i][0][1].tolist(), 
+               picks_batch[i][1][0].tolist(), picks_batch[i][1][1].tolist()]
+        writer.writerow(row)
 
     fclog.close()
     print("Done")


### PR DESCRIPTION
I described issue https://github.com/wayneweiqiang/PhaseNet/issues/9 a while ago and here is the PR with the fix. The fix is a two-part solution. 

First, I open the `picks.csv` file in the write `w` mode with the `csv.writer` from the [csv library](https://docs.python.org/3/library/csv.html) and write the header row. The write `w` mode will overwrite any existing file with the same filename.

I then open picks.csv in the append `a` mode and write the results to `picks.csv` by looping through each batch. The results are converted from arrays to lists with the `tolist()` method which removes the excess white spaces. I then append the results to the csv with the `writerow()` method by passing the results in list format. This automatically delimits the csv columns into `fname`, `itp`, `tp_prob`, `its`, `ts_prob` and adresses any issues like overfull lines automatically (see issue https://github.com/wayneweiqiang/PhaseNet/issues/6). 

I have tried and tested the method and it works as hoped. When reading the csv files with `pandas`, one should still note that the `pandas.read_csv()` method will default to reading all entries as strings. This is described fully in a [stackoverflow post](https://stackoverflow.com/questions/23111990/pandas-dataframe-stored-list-as-string-how-to-convert-back-to-list). An easy fix is using the `literal_eval` method from `ast`. 
```
>>> from ast import literal_eval
>>> literal_eval('[1.23, 2.34]')
[1.23, 2.34]
```
Best,
Lenni